### PR TITLE
deps: updates wazero to 1.0.0-pre.3

### DIFF
--- a/wasmapp/go.mod
+++ b/wasmapp/go.mod
@@ -2,4 +2,4 @@ module github.com/threadedstream/wasmapp
 
 go 1.18
 
-require github.com/tetratelabs/wazero v1.0.0-pre.2
+require github.com/tetratelabs/wazero v1.0.0-pre.3

--- a/wasmapp/go.sum
+++ b/wasmapp/go.sum
@@ -1,2 +1,2 @@
-github.com/tetratelabs/wazero v1.0.0-pre.2 h1:sHYi8DKUL7s7c4sKz6lw0pNqky5EogYK0Iq4pSIsDog=
-github.com/tetratelabs/wazero v1.0.0-pre.2/go.mod h1:M8UDNECGm/HVjOfq0EOe4QfCY9Les1eq54IChMLETbc=
+github.com/tetratelabs/wazero v1.0.0-pre.3 h1:Z5fbogMUGcERzaQb9mQU8+yJSy0bVvv2ce3dfR4wcZg=
+github.com/tetratelabs/wazero v1.0.0-pre.3/go.mod h1:M8UDNECGm/HVjOfq0EOe4QfCY9Les1eq54IChMLETbc=

--- a/wasmapp/main.go
+++ b/wasmapp/main.go
@@ -20,7 +20,7 @@ func main() {
 	defer r.Close(ctx)
 
 	_, err := r.NewHostModuleBuilder("env").
-		ExportFunction("log", logString).
+		NewFunctionBuilder().WithFunc(logString).Export("log").
 		Instantiate(ctx, r)
 	if err != nil {
 		log.Panicln(err)


### PR DESCRIPTION
This updates [wazero](https://wazero.io/) to [1.0.0-pre.3](https://github.com/tetratelabs/wazero/releases/tag/v1.0.0-pre.3). This is the last release that will build with Go 1.17.

Notably, this improves performance and changes host function syntax.